### PR TITLE
Following the Reactive pattern a bit more closely to avoid overshadowing

### DIFF
--- a/Gooey.podspec
+++ b/Gooey.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'Gooey'
-  s.version               = '1.0.1'
+  s.version               = '1.0.2'
   s.summary               = 'UIKit extensions and helpers to make everyday iOS development simpler.'
   s.description           = "UIKit extensions for simplifying development. Includes extensions for handling safeAreaLayoutGuide with backwards compatibility, less verbose reusable views, and more."
   s.license               = { type: 'MIT', file: 'LICENSE' }

--- a/Gooey/Sources/GooeyNamespaceProxy.swift
+++ b/Gooey/Sources/GooeyNamespaceProxy.swift
@@ -14,3 +14,22 @@ public struct GooeyNamespace<Base> {
     }
 
 }
+
+public protocol GooeyCompatible {
+
+    associatedtype CompatibleType
+    var goo: GooeyNamespace<CompatibleType> { get }
+
+}
+
+extension GooeyCompatible {
+
+    public var goo: GooeyNamespace<Self> {
+        get {
+            return GooeyNamespace(base: self)
+        }
+    }
+
+}
+
+extension NSObject: GooeyCompatible {}

--- a/Gooey/Sources/UIView.swift
+++ b/Gooey/Sources/UIView.swift
@@ -222,14 +222,6 @@ public class ConstraintGroup<A: LayoutAxis> {
 
 }
 
-public extension UIView {
-
-    public var goo: GooeyNamespace<UIView> {
-        return GooeyNamespace(base: self)
-    }
-
-}
-
 public extension GooeyNamespace where Base: UIView {
 
     /// Returns a layout anchor representing the entire bounds of a view.

--- a/Gooey/Sources/UIViewController.swift
+++ b/Gooey/Sources/UIViewController.swift
@@ -1,13 +1,5 @@
 import UIKit
 
-public extension UIViewController {
-
-    public var goo: GooeyNamespace<UIViewController> {
-        return GooeyNamespace(base: self)
-    }
-    
-}
-
 public extension GooeyNamespace where Base: UIViewController {
 
     /// Returns the top layout anchor for the view controller's view.


### PR DESCRIPTION
relevant namespaces.