### PR TITLE
Add a `ConstraintRepresentable` protocol.

### DIFF
--- a/Gooey.xcodeproj/project.pbxproj
+++ b/Gooey.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		B56F006021F66BC600F29145 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56F005E21F66BC600F29145 /* Nimble.framework */; };
 		B5747A6A21F67FF0009C80C1 /* Quick.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = B56F005D21F66BC600F29145 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B5747A6B21F67FF5009C80C1 /* Nimble.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = B56F005E21F66BC600F29145 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EA4D772E22BC8FA1008CDB87 /* ConstraintRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D772D22BC8FA1008CDB87 /* ConstraintRepresentable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		B55BB477202BA5A700B3C865 /* UIView+AccessibilitySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+AccessibilitySpec.swift"; sourceTree = "<group>"; };
 		B56F005D21F66BC600F29145 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		B56F005E21F66BC600F29145 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
+		EA4D772D22BC8FA1008CDB87 /* ConstraintRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintRepresentable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +167,7 @@
 				94F30FA620598CAB0073B904 /* Bounding Anchor */,
 				941D3A5621665FC80044DC5F /* CGFloat.swift */,
 				94398128206ADFC8002AD1CA /* Color.swift */,
+				EA4D772D22BC8FA1008CDB87 /* ConstraintRepresentable.swift */,
 				B55BB472202BA3C300B3C865 /* GooeyNamespaceProxy.swift */,
 				941D3A58216661310044DC5F /* NSLayoutAnchor.swift */,
 				B55BB470202BA3AE00B3C865 /* Reusability.swift */,
@@ -323,6 +326,7 @@
 				94B6AF8820F79FDE00E185FC /* UIStackView.swift in Sources */,
 				B55BB469202BA2BF00B3C865 /* UITableView.swift in Sources */,
 				B55BB471202BA3AE00B3C865 /* Reusability.swift in Sources */,
+				EA4D772E22BC8FA1008CDB87 /* ConstraintRepresentable.swift in Sources */,
 				94F30FA820598CC30073B904 /* BoundingAnchor.swift in Sources */,
 				B55BB46D202BA33800B3C865 /* UINavigationController.swift in Sources */,
 			);

--- a/Gooey/Sources/Bounding Anchor/ConstraintGroup.swift
+++ b/Gooey/Sources/Bounding Anchor/ConstraintGroup.swift
@@ -25,9 +25,9 @@ fileprivate extension NSLayoutConstraint {
 
 /// The `ConstraintGroup` type is a factory decorator for applying symmetric changes to grouped
 /// `NSLayoutConstraint` objects using a fluent interface.
-public class ConstraintGroup<A: LayoutAxis> {
+public class ConstraintGroup<A: LayoutAxis>: ConstraintRepresentable {
 
-    let constraints: [NSLayoutConstraint]
+    public let constraints: [NSLayoutConstraint]
     private var insets: UIEdgeInsets
 
     init<A>(constraints: [NSLayoutConstraint], insets: EdgeInsets<A>) {

--- a/Gooey/Sources/ConstraintRepresentable.swift
+++ b/Gooey/Sources/ConstraintRepresentable.swift
@@ -21,6 +21,16 @@ public extension GooeyNamespace where Base == NSLayoutConstraint.Type {
 
     /// The effect of this method is the same as setting the
     ///     [isActive](apple-reference-documentation://hsRIb14KxL) property of
+    ///     each constraint to `true`.
+    ///
+    /// - Parameter constraintRepresentables: Constraint representable
+    ///      conforming objects to be activated.
+    func activate(_ constraintRepresentables: [ConstraintRepresentable]) {
+        NSLayoutConstraint.activate(constraintRepresentables.reduce(into: [], { $0.append(contentsOf: $1.constraints) }))
+    }
+
+    /// The effect of this method is the same as setting the
+    ///     [isActive](apple-reference-documentation://hsRIb14KxL) property of
     ///     each constraint to `false`.
     ///
     /// - Parameter constraintRepresentable: A constraint representable
@@ -29,20 +39,22 @@ public extension GooeyNamespace where Base == NSLayoutConstraint.Type {
         NSLayoutConstraint.deactivate(constraintRepresentable.constraints)
     }
 
+    /// The effect of this method is the same as setting the
+    ///     [isActive](apple-reference-documentation://hsRIb14KxL) property of
+    ///     each constraint to `false`.
+    ///
+    /// - Parameter constraintRepresentables: Constraint representable
+    ///      conforming objects to be activated.
+    func deactivate(_ constraintRepresentables: [ConstraintRepresentable]) {
+        NSLayoutConstraint.deactivate(constraintRepresentables.reduce(into: [], { $0.append(contentsOf: $1.constraints) }))
+    }
+
 }
 
 extension NSLayoutConstraint: ConstraintRepresentable {
 
     public var constraints: [NSLayoutConstraint] {
         return [self]
-    }
-
-}
-
-extension Array: ConstraintRepresentable where Element: ConstraintRepresentable {
-
-    public var constraints: [NSLayoutConstraint] {
-        return reduce(into: [], { $0.append(contentsOf: $1.constraints) })
     }
 
 }

--- a/Gooey/Sources/ConstraintRepresentable.swift
+++ b/Gooey/Sources/ConstraintRepresentable.swift
@@ -1,0 +1,48 @@
+import Foundation
+import UIKit
+
+public protocol ConstraintRepresentable {
+
+    var constraints: [NSLayoutConstraint] { get }
+
+}
+
+public extension GooeyNamespace where Base == NSLayoutConstraint.Type {
+
+    /// The effect of this method is the same as setting the
+    ///     [isActive](apple-reference-documentation://hsRIb14KxL) property of
+    ///     each constraint to `true`.
+    ///
+    /// - Parameter constraintRepresentable: A constraint representable
+    ///      conforming object to be activated.
+    func activate(_ constraintRepresentable: ConstraintRepresentable) {
+        NSLayoutConstraint.activate(constraintRepresentable.constraints)
+    }
+
+    /// The effect of this method is the same as setting the
+    ///     [isActive](apple-reference-documentation://hsRIb14KxL) property of
+    ///     each constraint to `false`.
+    ///
+    /// - Parameter constraintRepresentable: A constraint representable
+    ///      conforming object to be deactivated.
+    func deactivate(_ constraintRepresentable: ConstraintRepresentable) {
+        NSLayoutConstraint.deactivate(constraintRepresentable.constraints)
+    }
+
+}
+
+extension NSLayoutConstraint: ConstraintRepresentable {
+
+    public var constraints: [NSLayoutConstraint] {
+        return [self]
+    }
+
+}
+
+extension Array: ConstraintRepresentable where Element: ConstraintRepresentable {
+
+    public var constraints: [NSLayoutConstraint] {
+        return reduce(into: [], { $0.append(contentsOf: $1.constraints) })
+    }
+
+}

--- a/Gooey/Sources/ConstraintRepresentable.swift
+++ b/Gooey/Sources/ConstraintRepresentable.swift
@@ -1,8 +1,10 @@
 import Foundation
 import UIKit
 
+/// A type that can be converted to a defining set of constraints.
 public protocol ConstraintRepresentable {
 
+    /// The corresponding set of constraints describing `self`.
     var constraints: [NSLayoutConstraint] { get }
 
 }

--- a/Gooey/Sources/ConstraintRepresentable.swift
+++ b/Gooey/Sources/ConstraintRepresentable.swift
@@ -44,7 +44,7 @@ public extension GooeyNamespace where Base == NSLayoutConstraint.Type {
     ///     each constraint to `false`.
     ///
     /// - Parameter constraintRepresentables: Constraint representable
-    ///      conforming objects to be activated.
+    ///      conforming objects to be deactivated.
     func deactivate(_ constraintRepresentables: [ConstraintRepresentable]) {
         NSLayoutConstraint.deactivate(constraintRepresentables.reduce(into: [], { $0.append(contentsOf: $1.constraints) }))
     }


### PR DESCRIPTION
Add a `ConstraintRepresentable` protocol to allow easier activation / deactivation of constraints.
This would allow mixing and mingling `NSLayoutConstraint`s and constraints produced by Gooey. This would also ensure all constraints get activated / deactivated with one call to `NSLayoutConstraint.activate`.

```
NSLayoutConstraint.goo.activate([
    view1.goo.boundingAnchor.makeEdges(equalTo: view2),
    view2.centerXAnchor.constrain(equalTo: view3.centerXAnchor)
])
```