### PR TITLE
Renames Gooey.Color to Gooey._Color and provides versioned names for …

### DIFF
--- a/Gooey.xcodeproj/project.pbxproj
+++ b/Gooey.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		94398129206ADFC8002AD1CA /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94398128206ADFC8002AD1CA /* Color.swift */; };
 		94B6AF8820F79FDE00E185FC /* UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B6AF8720F79FDE00E185FC /* UIStackView.swift */; };
 		94B8419E22B1241200205AD1 /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B8419D22B1241200205AD1 /* UILabel.swift */; };
+		94CF27E322F06EBA000B80B6 /* ColorTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CF27E222F06EBA000B80B6 /* ColorTokenTests.swift */; };
+		94CF27E422F0704D000B80B6 /* ConstraintGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA93A48622BCA7100003CC04 /* ConstraintGroupTests.swift */; };
+		94CF27E522F0704D000B80B6 /* UIView+AccessibilitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB477202BA5A700B3C865 /* UIView+AccessibilitySpec.swift */; };
 		94F30F9F20530A060073B904 /* SafeAreaLayoutGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30F9E20530A060073B904 /* SafeAreaLayoutGuide.swift */; };
 		94F30FA820598CC30073B904 /* BoundingAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30FA720598CC30073B904 /* BoundingAnchor.swift */; };
 		94F30FAA20598CCD0073B904 /* ConstraintGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30FA920598CCD0073B904 /* ConstraintGroup.swift */; };
@@ -28,13 +31,11 @@
 		B55BB471202BA3AE00B3C865 /* Reusability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB470202BA3AE00B3C865 /* Reusability.swift */; };
 		B55BB473202BA3C400B3C865 /* GooeyNamespaceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB472202BA3C300B3C865 /* GooeyNamespaceProxy.swift */; };
 		B55BB475202BA3D000B3C865 /* UIView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB474202BA3D000B3C865 /* UIView+Accessibility.swift */; };
-		B55BB478202BA5A700B3C865 /* UIView+AccessibilitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB477202BA5A700B3C865 /* UIView+AccessibilitySpec.swift */; };
 		B56F005F21F66BC600F29145 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56F005D21F66BC600F29145 /* Quick.framework */; };
 		B56F006021F66BC600F29145 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56F005E21F66BC600F29145 /* Nimble.framework */; };
 		B5747A6A21F67FF0009C80C1 /* Quick.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = B56F005D21F66BC600F29145 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B5747A6B21F67FF5009C80C1 /* Nimble.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = B56F005E21F66BC600F29145 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EA4D772E22BC8FA1008CDB87 /* ConstraintRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D772D22BC8FA1008CDB87 /* ConstraintRepresentable.swift */; };
-		EA93A48722BCA7100003CC04 /* ConstraintGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA93A48622BCA7100003CC04 /* ConstraintGroupTests.swift */; };
 		EADEAB9C22BCB1C20049308E /* NSLayoutConstraint+Targets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADEAB9B22BCB1C20049308E /* NSLayoutConstraint+Targets.swift */; };
 /* End PBXBuildFile section */
 
@@ -72,6 +73,7 @@
 		94398128206ADFC8002AD1CA /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		94B6AF8720F79FDE00E185FC /* UIStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackView.swift; sourceTree = "<group>"; };
 		94B8419D22B1241200205AD1 /* UILabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
+		94CF27E222F06EBA000B80B6 /* ColorTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTokenTests.swift; sourceTree = "<group>"; };
 		94F30F9E20530A060073B904 /* SafeAreaLayoutGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaLayoutGuide.swift; sourceTree = "<group>"; };
 		94F30FA720598CC30073B904 /* BoundingAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingAnchor.swift; sourceTree = "<group>"; };
 		94F30FA920598CCD0073B904 /* ConstraintGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintGroup.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 			children = (
 				EA93A48622BCA7100003CC04 /* ConstraintGroupTests.swift */,
 				B55BB477202BA5A700B3C865 /* UIView+AccessibilitySpec.swift */,
+				94CF27E222F06EBA000B80B6 /* ColorTokenTests.swift */,
 				B55BB45B202BA1E200B3C865 /* Info.plist */,
 			);
 			path = GooeyTests;
@@ -343,8 +346,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EA93A48722BCA7100003CC04 /* ConstraintGroupTests.swift in Sources */,
-				B55BB478202BA5A700B3C865 /* UIView+AccessibilitySpec.swift in Sources */,
+				94CF27E522F0704D000B80B6 /* UIView+AccessibilitySpec.swift in Sources */,
+				94CF27E422F0704D000B80B6 /* ConstraintGroupTests.swift in Sources */,
+				94CF27E322F06EBA000B80B6 /* ColorTokenTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Gooey/Sources/Color.swift
+++ b/Gooey/Sources/Color.swift
@@ -1,8 +1,17 @@
 import Foundation
 import UIKit
 
+#if canImport(SwiftUI)
+public typealias ColorToken = _Color
+#else
+public typealias Color = _Color
+#endif
+
 /// Provides a unified convenience API for colors with a focus on brevity.
-public struct Color {
+///
+/// You should prefer using this type only by its exported typealias: `ColorToken` when targeting
+/// iOS 13 with SwiftUI or `Color` when targeting iOS 12.
+public struct _Color {
 
     /// The location of the alpha component in representations of this value.
     public enum AlphaLocation {
@@ -104,35 +113,35 @@ public struct Color {
     }
     
     /// Returns a color whose components are tinted by the supplied value.
-    public func tinted(by value: UInt8) -> Color {
+    public func tinted(by value: UInt8) -> _Color {
         let clampToUInt8: (UInt8, UInt8) -> UInt8 = { UInt8(min(Int(UInt8.max), Int($0) + Int($1))) }
-        return Color(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
+        return _Color(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
     }
     
     /// Returns a color whose components are shaded by the supplied value.
-    public func shaded(by value: UInt8) -> Color {
+    public func shaded(by value: UInt8) -> _Color {
         let clampToUInt8: (UInt8, UInt8) -> UInt8 = { UInt8(max(0, Int($0) - Int($1))) }
-        return Color(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
+        return _Color(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
     }
     
     /// Creates and returns a new color by substituting the red component of this color.
-    public func withRed(_ red: UInt8) -> Color {
-        return Color(red, green, blue, alpha)
+    public func withRed(_ red: UInt8) -> _Color {
+        return _Color(red, green, blue, alpha)
     }
     
     /// Creates and returns a new color by substituting the green component of this color.
-    public func withGreen(_ green: UInt8) -> Color {
-        return Color(red, green, blue, alpha)
+    public func withGreen(_ green: UInt8) -> _Color {
+        return _Color(red, green, blue, alpha)
     }
     
     /// Creates and returns a new color by substituting the blue component of this color.
-    public func withBlue(_ blue: UInt8) -> Color {
-        return Color(red, green, blue, alpha)
+    public func withBlue(_ blue: UInt8) -> _Color {
+        return _Color(red, green, blue, alpha)
     }
     
     /// Creates and returns a new color by substituting the alpha component of this color.
-    public func withAlpha(_ alpha: UInt8) -> Color {
-        return Color(red, green, blue, alpha)
+    public func withAlpha(_ alpha: UInt8) -> _Color {
+        return _Color(red, green, blue, alpha)
     }
     
     /// Returns the hex string literal which represents this color.
@@ -151,61 +160,61 @@ public struct Color {
     
 }
 
-public extension Color {
+public extension _Color {
     
     /// The red hue.
-    static let red = Color(255, 0, 0)
+    static let red = _Color(255, 0, 0)
     
     /// The orange hue.
-    static let orange = Color(255, 127, 0)
+    static let orange = _Color(255, 127, 0)
     
     /// The yellow hue.
-    static let yellow = Color(255, 255, 0)
+    static let yellow = _Color(255, 255, 0)
     
     /// The green hue.
-    static let green = Color(0, 255, 0)
+    static let green = _Color(0, 255, 0)
 
     /// The cyan hue.
-    static let cyan = Color(0, 255, 255)
+    static let cyan = _Color(0, 255, 255)
     
     /// The blue hue.
-    static let blue = Color(0, 0, 255)
+    static let blue = _Color(0, 0, 255)
     
     /// The purple hue.
-    static let purple = Color(127, 0, 127)
+    static let purple = _Color(127, 0, 127)
     
     /// The white color.
-    static let white = Color(255, 255, 255)
+    static let white = _Color(255, 255, 255)
     
     /// The black color.
-    static let black = Color(0, 0, 0)
+    static let black = _Color(0, 0, 0)
     
     /// A clear black color.
-    static let clear = Color(0, 0, 0, 0)
+    static let clear = _Color(0, 0, 0, 0)
     
     /// The system-appearance red color.
-    static let systemRed = Color(255, 59, 48)
+    static let systemRed = _Color(255, 59, 48)
     
     /// The system-appearance orange color.
-    static let systemOrange = Color(255, 149, 0)
+    static let systemOrange = _Color(255, 149, 0)
     
     /// The system-appearance yellow color.
-    static let systemYellow = Color(255, 204, 0)
+    static let systemYellow = _Color(255, 204, 0)
     
     /// The system-appearance green color.
-    static let systemGreen = Color(76, 217, 100)
+    static let systemGreen = _Color(76, 217, 100)
     
     /// The system-appearance teal blue color.
-    static let systemTealBlue = Color(90, 200, 250)
+    static let systemTealBlue = _Color(90, 200, 250)
     
     /// The system-appearance blue color.
-    static let systemBlue = Color(0, 122, 255)
+    static let systemBlue = _Color(0, 122, 255)
     
     /// The system-appearance purple color.
-    static let systemPurple = Color(88, 86, 214)
+    static let systemPurple = _Color(88, 86, 214)
     
     /// The system-appearance pink color.
-    static let systemPink = Color(255, 45, 85)
+    static let systemPink = _Color(255, 45, 85)
     
 }
 

--- a/Gooey/Sources/Color.swift
+++ b/Gooey/Sources/Color.swift
@@ -1,17 +1,15 @@
 import Foundation
 import UIKit
 
-#if canImport(SwiftUI)
-public typealias ColorToken = _Color
-#else
-public typealias Color = _Color
+#if !canImport(SwiftUI)
+public typealias Color = ColorToken
 #endif
 
 /// Provides a unified convenience API for colors with a focus on brevity.
 ///
 /// You should prefer using this type only by its exported typealias: `ColorToken` when targeting
 /// iOS 13 with SwiftUI or `Color` when targeting iOS 12.
-public struct _Color {
+public struct ColorToken {
 
     /// The location of the alpha component in representations of this value.
     public enum AlphaLocation {
@@ -113,35 +111,35 @@ public struct _Color {
     }
     
     /// Returns a color whose components are tinted by the supplied value.
-    public func tinted(by value: UInt8) -> _Color {
+    public func tinted(by value: UInt8) -> ColorToken {
         let clampToUInt8: (UInt8, UInt8) -> UInt8 = { UInt8(min(Int(UInt8.max), Int($0) + Int($1))) }
-        return _Color(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
+        return ColorToken(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
     }
     
     /// Returns a color whose components are shaded by the supplied value.
-    public func shaded(by value: UInt8) -> _Color {
+    public func shaded(by value: UInt8) -> ColorToken {
         let clampToUInt8: (UInt8, UInt8) -> UInt8 = { UInt8(max(0, Int($0) - Int($1))) }
-        return _Color(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
+        return ColorToken(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
     }
     
     /// Creates and returns a new color by substituting the red component of this color.
-    public func withRed(_ red: UInt8) -> _Color {
-        return _Color(red, green, blue, alpha)
+    public func withRed(_ red: UInt8) -> ColorToken {
+        return ColorToken(red, green, blue, alpha)
     }
     
     /// Creates and returns a new color by substituting the green component of this color.
-    public func withGreen(_ green: UInt8) -> _Color {
-        return _Color(red, green, blue, alpha)
+    public func withGreen(_ green: UInt8) -> ColorToken {
+        return ColorToken(red, green, blue, alpha)
     }
     
     /// Creates and returns a new color by substituting the blue component of this color.
-    public func withBlue(_ blue: UInt8) -> _Color {
-        return _Color(red, green, blue, alpha)
+    public func withBlue(_ blue: UInt8) -> ColorToken {
+        return ColorToken(red, green, blue, alpha)
     }
     
     /// Creates and returns a new color by substituting the alpha component of this color.
-    public func withAlpha(_ alpha: UInt8) -> _Color {
-        return _Color(red, green, blue, alpha)
+    public func withAlpha(_ alpha: UInt8) -> ColorToken {
+        return ColorToken(red, green, blue, alpha)
     }
     
     /// Returns the hex string literal which represents this color.
@@ -160,61 +158,61 @@ public struct _Color {
     
 }
 
-public extension _Color {
+public extension ColorToken {
     
     /// The red hue.
-    static let red = _Color(255, 0, 0)
+    static let red = ColorToken(255, 0, 0)
     
     /// The orange hue.
-    static let orange = _Color(255, 127, 0)
+    static let orange = ColorToken(255, 127, 0)
     
     /// The yellow hue.
-    static let yellow = _Color(255, 255, 0)
+    static let yellow = ColorToken(255, 255, 0)
     
     /// The green hue.
-    static let green = _Color(0, 255, 0)
+    static let green = ColorToken(0, 255, 0)
 
     /// The cyan hue.
-    static let cyan = _Color(0, 255, 255)
+    static let cyan = ColorToken(0, 255, 255)
     
     /// The blue hue.
-    static let blue = _Color(0, 0, 255)
+    static let blue = ColorToken(0, 0, 255)
     
     /// The purple hue.
-    static let purple = _Color(127, 0, 127)
+    static let purple = ColorToken(127, 0, 127)
     
     /// The white color.
-    static let white = _Color(255, 255, 255)
+    static let white = ColorToken(255, 255, 255)
     
     /// The black color.
-    static let black = _Color(0, 0, 0)
+    static let black = ColorToken(0, 0, 0)
     
     /// A clear black color.
-    static let clear = _Color(0, 0, 0, 0)
+    static let clear = ColorToken(0, 0, 0, 0)
     
     /// The system-appearance red color.
-    static let systemRed = _Color(255, 59, 48)
+    static let systemRed = ColorToken(255, 59, 48)
     
     /// The system-appearance orange color.
-    static let systemOrange = _Color(255, 149, 0)
+    static let systemOrange = ColorToken(255, 149, 0)
     
     /// The system-appearance yellow color.
-    static let systemYellow = _Color(255, 204, 0)
+    static let systemYellow = ColorToken(255, 204, 0)
     
     /// The system-appearance green color.
-    static let systemGreen = _Color(76, 217, 100)
+    static let systemGreen = ColorToken(76, 217, 100)
     
     /// The system-appearance teal blue color.
-    static let systemTealBlue = _Color(90, 200, 250)
+    static let systemTealBlue = ColorToken(90, 200, 250)
     
     /// The system-appearance blue color.
-    static let systemBlue = _Color(0, 122, 255)
+    static let systemBlue = ColorToken(0, 122, 255)
     
     /// The system-appearance purple color.
-    static let systemPurple = _Color(88, 86, 214)
+    static let systemPurple = ColorToken(88, 86, 214)
     
     /// The system-appearance pink color.
-    static let systemPink = _Color(255, 45, 85)
+    static let systemPink = ColorToken(255, 45, 85)
     
 }
 

--- a/Gooey/Sources/Color.swift
+++ b/Gooey/Sources/Color.swift
@@ -54,7 +54,7 @@ public struct ColorToken {
         return alpha.percent
     }
 
-    /// Returns the hue of this color (of degrees out of 360º) represented as a percent in 0...1.
+    /// Returns the hue of this color (of degrees out of 360°) represented as a percent in 0...1.
     var hue: CGFloat {
         if max(red, green, blue) == min(red, green, blue) { return 0 }
         let delta = value - min(percentRed, percentGreen, percentBlue)

--- a/Gooey/Sources/Color.swift
+++ b/Gooey/Sources/Color.swift
@@ -55,7 +55,7 @@ public struct ColorToken {
     }
 
     /// Returns the hue of this color (of degrees out of 360°) represented as a percent in 0...1.
-    var hue: CGFloat {
+    public var hue: CGFloat {
         if max(red, green, blue) == min(red, green, blue) { return 0 }
         let delta = value - min(percentRed, percentGreen, percentBlue)
         let absolute: CGFloat
@@ -70,12 +70,12 @@ public struct ColorToken {
     }
 
     /// Returns the saturation of this color represented as a percent in 0...1.
-    var saturation: CGFloat {
+    public var saturation: CGFloat {
         return max(red, green, blue) == 0 ? 0 : (value - min(percentRed, percentGreen, percentBlue)) / value
     }
 
     /// Returns the value of this color represented as a percent in 0...1.
-    var value: CGFloat {
+    public var value: CGFloat {
         return max(percentRed, percentGreen, percentBlue)
     }
     

--- a/GooeyTests/ColorTokenTests.swift
+++ b/GooeyTests/ColorTokenTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+@testable import Gooey
+
+class ColorTokenTests: XCTestCase {
+
+    func testInitializingWithHSV() {
+        let actualRed = ColorToken(hue: 0, saturation: 1, value: 1)
+        let expectedRed = ColorToken.red
+        XCTAssertEqual(actualRed.red, expectedRed.red)
+        XCTAssertEqual(actualRed.green, expectedRed.green)
+        XCTAssertEqual(actualRed.blue, expectedRed.blue)
+        let actualPurple = ColorToken(hue: 5 / 6, saturation: 1, value: 0.498)
+        let expectedPurple = ColorToken.purple
+        XCTAssertEqual(actualPurple.red, expectedPurple.red)
+        XCTAssertEqual(actualPurple.green, expectedPurple.green)
+        XCTAssertEqual(actualPurple.blue, expectedPurple.blue)
+        let randomBlack = ColorToken(hue: .random(in: 0...1), saturation: .random(in: 0...1), value: 0)
+        let expectedBlack = ColorToken.black
+        XCTAssertEqual(randomBlack.red, expectedBlack.red)
+        XCTAssertEqual(randomBlack.green, expectedBlack.green)
+        XCTAssertEqual(randomBlack.blue, expectedBlack.blue)
+        let randomWhite = ColorToken(hue: .random(in: 0...1), saturation: 0, value: 1)
+        let expectedWhite = ColorToken.white
+        XCTAssertEqual(randomWhite.red, expectedWhite.red)
+        XCTAssertEqual(randomWhite.green, expectedWhite.green)
+        XCTAssertEqual(randomWhite.blue, expectedWhite.blue)
+    }
+
+    func testAccessingHue() {
+        XCTAssertEqual(ColorToken.red.hue, 0)
+        XCTAssertEqual(ColorToken.purple.hue, 5 / 6)
+        XCTAssertEqual(ColorToken.white.hue, 0)
+        XCTAssertEqual(ColorToken.black.hue, 0)
+    }
+
+    func testAccessingSaturation() {
+        XCTAssertEqual(ColorToken.red.saturation, 1)
+        XCTAssertEqual(ColorToken.black.saturation, 0)
+        XCTAssertEqual(ColorToken.white.saturation, 0)
+    }
+
+    func testAccessingValue() {
+        XCTAssertEqual(ColorToken.red.value, 1)
+        XCTAssertEqual(ColorToken.black.value, 0)
+        XCTAssertEqual(ColorToken.white.value, 1)
+        XCTAssertEqual(ColorToken.purple.value, 0.498, accuracy: 0.0001)
+    }
+
+}


### PR DESCRIPTION
…the type: Color for iOS 12 and ColorToken for iOS 13. Unfortunately, the compiler is unable to resolve any usages of Color when both Gooey and SwiftUI are imported.