### PR TITLE
Modify priority of constraint groups, add `byAxis` to EdgeInsets<Bounds>

### DIFF
--- a/Gooey.podspec
+++ b/Gooey.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'Gooey'
-  s.version               = '3.1.0'
+  s.version               = '3.2.0'
   s.summary               = 'UIKit extensions and helpers to make everyday iOS development simpler.'
   s.description           = "UIKit extensions for simplifying development. Includes extensions for handling safeAreaLayoutGuide with backwards compatibility, less verbose reusable views, and more."
   s.license               = { type: 'MIT', file: 'LICENSE' }

--- a/Gooey.xcodeproj/project.pbxproj
+++ b/Gooey.xcodeproj/project.pbxproj
@@ -16,13 +16,11 @@
 		94B6AF8820F79FDE00E185FC /* UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B6AF8720F79FDE00E185FC /* UIStackView.swift */; };
 		94B8419E22B1241200205AD1 /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B8419D22B1241200205AD1 /* UILabel.swift */; };
 		94D985A722E72D3B004DFA45 /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D985A622E72D3B004DFA45 /* UIBarButtonItem.swift */; };
-		94CF27E322F06EBA000B80B6 /* ColorTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CF27E222F06EBA000B80B6 /* ColorTokenTests.swift */; };
-		94CF27E422F0704D000B80B6 /* ConstraintGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA93A48622BCA7100003CC04 /* ConstraintGroupTests.swift */; };
-		94CF27E522F0704D000B80B6 /* UIView+AccessibilitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB477202BA5A700B3C865 /* UIView+AccessibilitySpec.swift */; };
 		94F30F9F20530A060073B904 /* SafeAreaLayoutGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30F9E20530A060073B904 /* SafeAreaLayoutGuide.swift */; };
 		94F30FA820598CC30073B904 /* BoundingAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30FA720598CC30073B904 /* BoundingAnchor.swift */; };
 		94F30FAA20598CCD0073B904 /* ConstraintGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30FA920598CCD0073B904 /* ConstraintGroup.swift */; };
 		94F30FAC20598D8A0073B904 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30FAB20598D8A0073B904 /* EdgeInsets.swift */; };
+		B514A098247558AD009FEF02 /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B514A097247558AD009FEF02 /* NSLayoutConstraint.swift */; };
 		B55BB467202BA27F00B3C865 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB466202BA27F00B3C865 /* UIView.swift */; };
 		B55BB469202BA2BF00B3C865 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB468202BA2BF00B3C865 /* UITableView.swift */; };
 		B55BB46B202BA30200B3C865 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB46A202BA30200B3C865 /* UIViewController.swift */; };
@@ -44,11 +42,11 @@
 		94B6AF8720F79FDE00E185FC /* UIStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackView.swift; sourceTree = "<group>"; };
 		94B8419D22B1241200205AD1 /* UILabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
 		94D985A622E72D3B004DFA45 /* UIBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItem.swift; sourceTree = "<group>"; };
-		94CF27E222F06EBA000B80B6 /* ColorTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTokenTests.swift; sourceTree = "<group>"; };
 		94F30F9E20530A060073B904 /* SafeAreaLayoutGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaLayoutGuide.swift; sourceTree = "<group>"; };
 		94F30FA720598CC30073B904 /* BoundingAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingAnchor.swift; sourceTree = "<group>"; };
 		94F30FA920598CCD0073B904 /* ConstraintGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintGroup.swift; sourceTree = "<group>"; };
 		94F30FAB20598D8A0073B904 /* EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsets.swift; sourceTree = "<group>"; };
+		B514A097247558AD009FEF02 /* NSLayoutConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraint.swift; sourceTree = "<group>"; };
 		B55BB44B202BA1E200B3C865 /* Gooey.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gooey.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B55BB44F202BA1E200B3C865 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B55BB466202BA27F00B3C865 /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
@@ -117,6 +115,7 @@
 				EA4D772D22BC8FA1008CDB87 /* ConstraintRepresentable.swift */,
 				B55BB472202BA3C300B3C865 /* GooeyNamespaceProxy.swift */,
 				941D3A58216661310044DC5F /* NSLayoutAnchor.swift */,
+				B514A097247558AD009FEF02 /* NSLayoutConstraint.swift */,
 				B55BB470202BA3AE00B3C865 /* Reusability.swift */,
 				94F30F9E20530A060073B904 /* SafeAreaLayoutGuide.swift */,
 				94D985A622E72D3B004DFA45 /* UIBarButtonItem.swift */,
@@ -230,6 +229,7 @@
 				B55BB46B202BA30200B3C865 /* UIViewController.swift in Sources */,
 				941D3A59216661310044DC5F /* NSLayoutAnchor.swift in Sources */,
 				B55BB473202BA3C400B3C865 /* GooeyNamespaceProxy.swift in Sources */,
+				B514A098247558AD009FEF02 /* NSLayoutConstraint.swift in Sources */,
 				941D3A5B216663870044DC5F /* UIEdgeInsets.swift in Sources */,
 				94B6AF8820F79FDE00E185FC /* UIStackView.swift in Sources */,
 				B55BB469202BA2BF00B3C865 /* UITableView.swift in Sources */,

--- a/Gooey.xcodeproj/project.pbxproj
+++ b/Gooey.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -21,6 +21,11 @@
 		94F30FAA20598CCD0073B904 /* ConstraintGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30FA920598CCD0073B904 /* ConstraintGroup.swift */; };
 		94F30FAC20598D8A0073B904 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F30FAB20598D8A0073B904 /* EdgeInsets.swift */; };
 		B514A098247558AD009FEF02 /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B514A097247558AD009FEF02 /* NSLayoutConstraint.swift */; };
+		B514A0A2247582C0009FEF02 /* Gooey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55BB44B202BA1E200B3C865 /* Gooey.framework */; };
+		B514A0AA247582DF009FEF02 /* ConstraintGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B514A0A8247582DF009FEF02 /* ConstraintGroupTests.swift */; };
+		B514A0AB247582DF009FEF02 /* ColorTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B514A0A9247582DF009FEF02 /* ColorTokenTests.swift */; };
+		B514A0AE2475831A009FEF02 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = B514A0AD2475831A009FEF02 /* Nimble */; };
+		B514A0B12475832E009FEF02 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = B514A0B02475832E009FEF02 /* Quick */; };
 		B55BB467202BA27F00B3C865 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB466202BA27F00B3C865 /* UIView.swift */; };
 		B55BB469202BA2BF00B3C865 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB468202BA2BF00B3C865 /* UITableView.swift */; };
 		B55BB46B202BA30200B3C865 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BB46A202BA30200B3C865 /* UIViewController.swift */; };
@@ -31,6 +36,16 @@
 		EA4D772E22BC8FA1008CDB87 /* ConstraintRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D772D22BC8FA1008CDB87 /* ConstraintRepresentable.swift */; };
 		EADEAB9C22BCB1C20049308E /* NSLayoutConstraint+Targets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADEAB9B22BCB1C20049308E /* NSLayoutConstraint+Targets.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B514A0A3247582C0009FEF02 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55BB442202BA1E200B3C865 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B55BB44A202BA1E200B3C865;
+			remoteInfo = Gooey;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		9410F9B32163A47200D04DC2 /* UILayoutGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILayoutGuide.swift; sourceTree = "<group>"; };
@@ -47,6 +62,10 @@
 		94F30FA920598CCD0073B904 /* ConstraintGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintGroup.swift; sourceTree = "<group>"; };
 		94F30FAB20598D8A0073B904 /* EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsets.swift; sourceTree = "<group>"; };
 		B514A097247558AD009FEF02 /* NSLayoutConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraint.swift; sourceTree = "<group>"; };
+		B514A09D247582C0009FEF02 /* GooeyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GooeyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B514A0A1247582C0009FEF02 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B514A0A8247582DF009FEF02 /* ConstraintGroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintGroupTests.swift; sourceTree = "<group>"; };
+		B514A0A9247582DF009FEF02 /* ColorTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorTokenTests.swift; sourceTree = "<group>"; };
 		B55BB44B202BA1E200B3C865 /* Gooey.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gooey.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B55BB44F202BA1E200B3C865 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B55BB466202BA27F00B3C865 /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
@@ -61,6 +80,16 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		B514A09A247582C0009FEF02 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B514A0B12475832E009FEF02 /* Quick in Frameworks */,
+				B514A0A2247582C0009FEF02 /* Gooey.framework in Frameworks */,
+				B514A0AE2475831A009FEF02 /* Nimble in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B55BB447202BA1E200B3C865 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -81,10 +110,21 @@
 			path = "Bounding Anchor";
 			sourceTree = "<group>";
 		};
+		B514A09E247582C0009FEF02 /* GooeyTests */ = {
+			isa = PBXGroup;
+			children = (
+				B514A0A9247582DF009FEF02 /* ColorTokenTests.swift */,
+				B514A0A8247582DF009FEF02 /* ConstraintGroupTests.swift */,
+				B514A0A1247582C0009FEF02 /* Info.plist */,
+			);
+			path = GooeyTests;
+			sourceTree = "<group>";
+		};
 		B55BB441202BA1E200B3C865 = {
 			isa = PBXGroup;
 			children = (
 				B55BB44D202BA1E200B3C865 /* Gooey */,
+				B514A09E247582C0009FEF02 /* GooeyTests */,
 				B55BB44C202BA1E200B3C865 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -93,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				B55BB44B202BA1E200B3C865 /* Gooey.framework */,
+				B514A09D247582C0009FEF02 /* GooeyTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -147,6 +188,28 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		B514A09C247582C0009FEF02 /* GooeyTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B514A0A5247582C0009FEF02 /* Build configuration list for PBXNativeTarget "GooeyTests" */;
+			buildPhases = (
+				B514A099247582C0009FEF02 /* Sources */,
+				B514A09A247582C0009FEF02 /* Frameworks */,
+				B514A09B247582C0009FEF02 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B514A0A4247582C0009FEF02 /* PBXTargetDependency */,
+			);
+			name = GooeyTests;
+			packageProductDependencies = (
+				B514A0AD2475831A009FEF02 /* Nimble */,
+				B514A0B02475832E009FEF02 /* Quick */,
+			);
+			productName = GooeyTests;
+			productReference = B514A09D247582C0009FEF02 /* GooeyTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		B55BB44A202BA1E200B3C865 /* Gooey */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B55BB45F202BA1E200B3C865 /* Build configuration list for PBXNativeTarget "Gooey" */;
@@ -171,10 +234,14 @@
 		B55BB442202BA1E200B3C865 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0920;
+				LastSwiftUpdateCheck = 1140;
 				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Duet Health";
 				TargetAttributes = {
+					B514A09C247582C0009FEF02 = {
+						CreatedOnToolsVersion = 11.4.1;
+						LastSwiftMigration = 1140;
+					};
 					B55BB44A202BA1E200B3C865 = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1020;
@@ -191,16 +258,28 @@
 				Base,
 			);
 			mainGroup = B55BB441202BA1E200B3C865;
+			packageReferences = (
+				B514A0AC2475831A009FEF02 /* XCRemoteSwiftPackageReference "Nimble" */,
+				B514A0AF2475832E009FEF02 /* XCRemoteSwiftPackageReference "Quick" */,
+			);
 			productRefGroup = B55BB44C202BA1E200B3C865 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				B55BB44A202BA1E200B3C865 /* Gooey */,
+				B514A09C247582C0009FEF02 /* GooeyTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		B514A09B247582C0009FEF02 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B55BB449202BA1E200B3C865 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -211,6 +290,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		B514A099247582C0009FEF02 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B514A0AA247582DF009FEF02 /* ConstraintGroupTests.swift in Sources */,
+				B514A0AB247582DF009FEF02 /* ColorTokenTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B55BB446202BA1E200B3C865 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -243,7 +331,59 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		B514A0A4247582C0009FEF02 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B55BB44A202BA1E200B3C865 /* Gooey */;
+			targetProxy = B514A0A3247582C0009FEF02 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		B514A0A6247582C0009FEF02 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = GooeyTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.duethealth.GooeyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B514A0A7247582C0009FEF02 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = GooeyTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.duethealth.GooeyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		B55BB45D202BA1E200B3C865 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -354,7 +494,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -374,7 +515,11 @@
 				INFOPLIST_FILE = Gooey/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.duet.Gooey;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -397,7 +542,11 @@
 				INFOPLIST_FILE = Gooey/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.duet.Gooey;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -409,6 +558,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		B514A0A5247582C0009FEF02 /* Build configuration list for PBXNativeTarget "GooeyTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B514A0A6247582C0009FEF02 /* Debug */,
+				B514A0A7247582C0009FEF02 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B55BB445202BA1E200B3C865 /* Build configuration list for PBXProject "Gooey" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -428,6 +586,38 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B514A0AC2475831A009FEF02 /* XCRemoteSwiftPackageReference "Nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Nimble.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.9;
+			};
+		};
+		B514A0AF2475832E009FEF02 /* XCRemoteSwiftPackageReference "Quick" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Quick.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B514A0AD2475831A009FEF02 /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B514A0AC2475831A009FEF02 /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+		B514A0B02475832E009FEF02 /* Quick */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B514A0AF2475832E009FEF02 /* XCRemoteSwiftPackageReference "Quick" */;
+			productName = Quick;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B55BB442202BA1E200B3C865 /* Project object */;
 }

--- a/Gooey.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Gooey.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Gooey.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Gooey/Sources/Bounding Anchor/ConstraintGroup.swift
+++ b/Gooey/Sources/Bounding Anchor/ConstraintGroup.swift
@@ -66,5 +66,12 @@ public class ConstraintGroup<A: LayoutAxis>: ConstraintRepresentable {
             right: patch.right == 0 ? current.right : patch.right
         )
     }
-    
+
+    public func with(priority: UILayoutPriority) -> ConstraintGroup<A> {
+        for constraint in constraints {
+            constraint.priority = priority
+        }
+        return self
+    }
+
 }

--- a/Gooey/Sources/Bounding Anchor/ConstraintGroup.swift
+++ b/Gooey/Sources/Bounding Anchor/ConstraintGroup.swift
@@ -67,7 +67,7 @@ public class ConstraintGroup<A: LayoutAxis>: ConstraintRepresentable {
         )
     }
 
-    public func with(priority: UILayoutPriority) -> ConstraintGroup<A> {
+    @discardableResult public func with(priority: UILayoutPriority) -> ConstraintGroup<A> {
         for constraint in constraints {
             constraint.priority = priority
         }

--- a/Gooey/Sources/Bounding Anchor/EdgeInsets.swift
+++ b/Gooey/Sources/Bounding Anchor/EdgeInsets.swift
@@ -103,6 +103,10 @@ public extension EdgeInsets where A == Bounds {
         return self.init(uiInsets: UIEdgeInsets(top: top, left: left, bottom: bottom, right: right))
     }
 
+    static func byAxis(horizontal: CGFloat = 0, vertical: CGFloat = 0) -> EdgeInsets<Bounds> {
+        return self.init(uiInsets: UIEdgeInsets(top: vertical, left: horizontal, bottom: vertical, right: horizontal))
+    }
+
     var left: CGFloat {
         return uiInsets.left
     }

--- a/Gooey/Sources/Bounding Anchor/EdgeInsets.swift
+++ b/Gooey/Sources/Bounding Anchor/EdgeInsets.swift
@@ -103,8 +103,8 @@ public extension EdgeInsets where A == Bounds {
         return self.init(uiInsets: UIEdgeInsets(top: top, left: left, bottom: bottom, right: right))
     }
 
-    static func byAxis(horizontal: CGFloat = 0, vertical: CGFloat = 0) -> EdgeInsets<Bounds> {
-        return self.init(uiInsets: UIEdgeInsets(top: vertical, left: horizontal, bottom: vertical, right: horizontal))
+    static func byAxis(horizontal: EdgeInsets<HorizontalAxis>, vertical: EdgeInsets<VerticalAxis>) -> EdgeInsets<Bounds> {
+        return self.init(uiInsets: UIEdgeInsets(top: vertical.top, left: horizontal.left, bottom: vertical.bottom, right: horizontal.right))
     }
 
     var left: CGFloat {

--- a/Gooey/Sources/Color.swift
+++ b/Gooey/Sources/Color.swift
@@ -23,16 +23,24 @@ public struct ColorToken {
     }
 
     /// The red component of this color.
-    public var red: UInt8
+    public var red: UInt8 {
+        return progeny.red
+    }
 
     /// The green component of this color.
-    public var green: UInt8
+    public var green: UInt8 {
+        return progeny.green
+    }
 
     /// The blue component of this color.
-    public var blue: UInt8
+    public var blue: UInt8 {
+        return progeny.blue
+    }
 
     /// The alpha component of this color.
-    public var alpha: UInt8
+    public var alpha: UInt8 {
+        return progeny.alpha
+    }
 
     /// Returns the red component of this color represented as a percent.
     public var percentRed: CGFloat {
@@ -56,7 +64,7 @@ public struct ColorToken {
 
     /// Returns the hue of this color (of degrees out of 360°) represented as a percent in 0...1.
     public var hue: CGFloat {
-        switch createdState {
+        switch progeny.createdState {
         case .hsv(let hue, _, _, _):
             return hue
         default:
@@ -76,7 +84,7 @@ public struct ColorToken {
 
     /// Returns the saturation of this color represented as a percent in 0...1.
     public var saturation: CGFloat {
-        switch createdState {
+        switch progeny.createdState {
         case .hsv(_, let saturation, _, _):
             return saturation
         default:
@@ -86,7 +94,7 @@ public struct ColorToken {
 
     /// Returns the value of this color represented as a percent in 0...1.
     public var value: CGFloat {
-        switch createdState {
+        switch progeny.createdState {
         case .hsv(_, _, let value, _):
             return value
         default:
@@ -112,7 +120,7 @@ public struct ColorToken {
 
     /// Returns the `UIColor` which corresponds with this color.
     public var uiColor: UIColor {
-        switch createdState {
+        switch progeny.createdState {
         case .uiColor(let color):
             return color
         default:
@@ -125,76 +133,26 @@ public struct ColorToken {
         return uiColor.cgColor
     }
 
-    private let createdState: CreatedState
+    private let progeny: Progeny
 
     /// Creates a color with the given component values.
     public init(_ red: UInt8, _ green: UInt8, _ blue: UInt8, _ alpha: UInt8 = .max) {
-        self.red = red
-        self.green = green
-        self.blue = blue
-        self.alpha = alpha
-        createdState = .rgba(red: red, green: green, blue: blue, alpha: alpha)
+        progeny = Progeny(createdState: .rgba(red: red, green: green, blue: blue, alpha: alpha))
     }
 
     /// Creates a color by calculating the components for the given percents.
     public init(percents red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat = 1) {
-        let toUInt8: (CGFloat) -> UInt8 = { UInt8(round(CGFloat(UInt8.max) * $0)) }
-        self.red = toUInt8(red)
-        self.green = toUInt8(green)
-        self.blue = toUInt8(blue)
-        self.alpha = toUInt8(alpha)
-        createdState = .percents(red: red, green: green, blue: blue, alpha: alpha)
+        progeny = Progeny(createdState: .percents(red: red, green: green, blue: blue, alpha: alpha))
     }
 
     /// Creates a color from the components of the given `UIColor`.
     public init(from uiColor: UIColor) {
-        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-        guard uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
-            fatalError("Could not initialize a Color from a UIColor.")
-        }
-        let toUInt8: (CGFloat) -> UInt8 = { UInt8(round(CGFloat(UInt8.max) * $0)) }
-        self.red = toUInt8(red)
-        self.green = toUInt8(green)
-        self.blue = toUInt8(blue)
-        self.alpha = toUInt8(alpha)
-        createdState = .uiColor(uiColor)
+        progeny = Progeny(createdState: .uiColor(uiColor))
     }
 
     /// Creates a color from the given hue, saturation, and value on the unit scale (0...1).
     public init(hue: CGFloat, saturation: CGFloat, value: CGFloat, alpha: CGFloat = 1) {
-        let c = max(0, min(1, value)) * max(0, min(1, saturation))
-        let x = c * (1 - abs(fmod((6 * max(0, min(1, hue))), 2) - 1))
-        let m = value - c
-        let percentRed: CGFloat
-        let percentGreen: CGFloat
-        let percentBlue: CGFloat
-        switch hue {
-        case 0..<(1 / 6):
-            percentRed = c
-            percentGreen = x
-            percentBlue = 0
-        case (1 / 6)..<(1 / 3):
-            percentRed = x
-            percentGreen = c
-            percentBlue = 0
-        case (1 / 3)..<(1 / 2):
-            percentRed = 0
-            percentGreen = c
-            percentBlue = x
-        case (1 / 2)..<(2 / 3):
-            percentRed = 0
-            percentGreen = x
-            percentBlue = c
-        case (2 / 3)..<(5 / 6):
-            percentRed = x
-            percentGreen = 0
-            percentBlue = c
-        default:
-            percentRed = c
-            percentGreen = 0
-            percentBlue = x
-        }
-        self.init(percents: percentRed + m, percentGreen + m, percentBlue + m, alpha)
+        progeny = Progeny(createdState: .hsv(hue: hue, saturation: saturation, value: value, alpha: alpha))
     }
 
     /// Returns a color whose components are tinted by the supplied value.
@@ -311,10 +269,89 @@ public extension ColorToken {
 
 }
 
+private extension CGFloat {
+
+    var toUInt8: UInt8 {
+        return UInt8((CGFloat(UInt8.max) * self).rounded())
+    }
+
+}
+
 private extension UInt8 {
 
     var percent: CGFloat {
         return CGFloat(self) / CGFloat(UInt8.max)
+    }
+
+}
+
+private struct Progeny {
+
+    let createdState: CreatedState
+    let red: UInt8
+    let green: UInt8
+    let blue: UInt8
+    let alpha: UInt8
+
+    init(createdState: CreatedState) {
+        self.createdState = createdState
+
+        switch createdState {
+            case .uiColor(let color):
+                let rgba = color.rgba
+                red = rgba.red.toUInt8
+                green = rgba.green.toUInt8
+                blue = rgba.blue.toUInt8
+                alpha = rgba.alpha.toUInt8
+            case .rgba(let red, let green, let blue, let alpha):
+                self.red = red
+                self.green = green
+                self.blue = blue
+                self.alpha = alpha
+            case .percents(let red, let green, let blue, let alpha):
+                self.red = red.toUInt8
+                self.green = green.toUInt8
+                self.blue = blue.toUInt8
+                self.alpha = alpha.toUInt8
+            case .hsv(let hue, let saturation, let value, let alpha):
+                let c = max(0, min(1, value)) * max(0, min(1, saturation))
+                let x = c * (1 - abs(fmod((6 * max(0, min(1, hue))), 2) - 1))
+                let m = value - c
+                let percentRed: CGFloat
+                let percentGreen: CGFloat
+                let percentBlue: CGFloat
+                switch hue {
+                case 0..<(1 / 6):
+                    percentRed = c
+                    percentGreen = x
+                    percentBlue = 0
+                case (1 / 6)..<(1 / 3):
+                    percentRed = x
+                    percentGreen = c
+                    percentBlue = 0
+                case (1 / 3)..<(1 / 2):
+                    percentRed = 0
+                    percentGreen = c
+                    percentBlue = x
+                case (1 / 2)..<(2 / 3):
+                    percentRed = 0
+                    percentGreen = x
+                    percentBlue = c
+                case (2 / 3)..<(5 / 6):
+                    percentRed = x
+                    percentGreen = 0
+                    percentBlue = c
+                default:
+                    percentRed = c
+                    percentGreen = 0
+                    percentBlue = x
+                }
+
+            red = (percentRed + m).toUInt8
+            green = (percentGreen + m).toUInt8
+            blue = (percentBlue + m).toUInt8
+            self.alpha = alpha.toUInt8
+        }
     }
 
 }
@@ -324,6 +361,18 @@ private enum CreatedState {
     case rgba(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8)
     case percents(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
     case uiColor(UIColor)
-    case hsv(CGFloat, saturation: CGFloat, value: CGFloat, alpha: CGFloat)
+    case hsv(hue: CGFloat, saturation: CGFloat, value: CGFloat, alpha: CGFloat)
+
+}
+
+extension UIColor {
+
+    var rgba: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        guard getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            fatalError("Could not initialize a Color from a UIColor.")
+        }
+        return (red, green, blue, alpha)
+    }
 
 }

--- a/Gooey/Sources/Color.swift
+++ b/Gooey/Sources/Color.swift
@@ -57,7 +57,7 @@ public struct ColorToken {
     /// Returns the hue of this color (of degrees out of 360°) represented as a percent in 0...1.
     public var hue: CGFloat {
         switch createdState {
-        case .hue(let hue, _, _, _):
+        case .hsv(let hue, _, _, _):
             return hue
         default:
             if max(red, green, blue) == min(red, green, blue) { return 0 }
@@ -77,7 +77,7 @@ public struct ColorToken {
     /// Returns the saturation of this color represented as a percent in 0...1.
     public var saturation: CGFloat {
         switch createdState {
-        case .hue(_, let saturation, _, _):
+        case .hsv(_, let saturation, _, _):
             return saturation
         default:
             return max(red, green, blue) == 0 ? 0 : (value - min(percentRed, percentGreen, percentBlue)) / value
@@ -87,7 +87,7 @@ public struct ColorToken {
     /// Returns the value of this color represented as a percent in 0...1.
     public var value: CGFloat {
         switch createdState {
-        case .hue(_, _, let value, _):
+        case .hsv(_, _, let value, _):
             return value
         default:
             return max(percentRed, percentGreen, percentBlue)
@@ -112,7 +112,7 @@ public struct ColorToken {
 
     /// Returns the `UIColor` which corresponds with this color.
     public var uiColor: UIColor {
-        switch createdState{
+        switch createdState {
         case .uiColor(let color):
             return color
         default:
@@ -324,6 +324,6 @@ private enum CreatedState {
     case rgba(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8)
     case percents(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
     case uiColor(UIColor)
-    case hue(CGFloat, saturation: CGFloat, value: CGFloat, alpha: CGFloat)
+    case hsv(CGFloat, saturation: CGFloat, value: CGFloat, alpha: CGFloat)
 
 }

--- a/Gooey/Sources/Color.swift
+++ b/Gooey/Sources/Color.swift
@@ -13,42 +13,42 @@ public struct ColorToken {
 
     /// The location of the alpha component in representations of this value.
     public enum AlphaLocation {
-        
+
         /// The alpha component comes before the color components.
         case leading
-        
+
         /// The alpha component comes after the color components.
         case trailing
-        
+
     }
-    
+
     /// The red component of this color.
     public var red: UInt8
-    
+
     /// The green component of this color.
     public var green: UInt8
-    
+
     /// The blue component of this color.
     public var blue: UInt8
-    
+
     /// The alpha component of this color.
     public var alpha: UInt8
-    
+
     /// Returns the red component of this color represented as a percent.
     public var percentRed: CGFloat {
         return red.percent
     }
-    
+
     /// Returns the green component of this color represented as a percent.
     public var percentGreen: CGFloat {
         return green.percent
     }
-    
+
     /// Returns the blue component of this color represented as a percent.
     public var percentBlue: CGFloat {
         return blue.percent
     }
-    
+
     /// Returns the alpha component of this color represented as a percent.
     public var percentAlpha: CGFloat {
         return alpha.percent
@@ -56,29 +56,44 @@ public struct ColorToken {
 
     /// Returns the hue of this color (of degrees out of 360°) represented as a percent in 0...1.
     public var hue: CGFloat {
-        if max(red, green, blue) == min(red, green, blue) { return 0 }
-        let delta = value - min(percentRed, percentGreen, percentBlue)
-        let absolute: CGFloat
-        if red >= green && red >= blue {
-            absolute = (60 * fmod((percentGreen - percentBlue) / delta, 6)) / 360
-        } else if green >= red && green >= blue {
-            absolute = (60 * ((percentBlue - percentRed) / delta + 2)) / 360
-        } else {
-            absolute = (60 * ((percentRed - percentGreen) / delta + 4)) / 360
+        switch createdState {
+        case .hue(let hue, _, _, _):
+            return hue
+        default:
+            if max(red, green, blue) == min(red, green, blue) { return 0 }
+            let delta = value - min(percentRed, percentGreen, percentBlue)
+            let absolute: CGFloat
+            if red >= green && red >= blue {
+                absolute = (60 * fmod((percentGreen - percentBlue) / delta, 6)) / 360
+            } else if green >= red && green >= blue {
+                absolute = (60 * ((percentBlue - percentRed) / delta + 2)) / 360
+            } else {
+                absolute = (60 * ((percentRed - percentGreen) / delta + 4)) / 360
+            }
+            return absolute < 0 ? absolute + 1 : absolute
         }
-        return absolute < 0 ? absolute + 1 : absolute
     }
 
     /// Returns the saturation of this color represented as a percent in 0...1.
     public var saturation: CGFloat {
-        return max(red, green, blue) == 0 ? 0 : (value - min(percentRed, percentGreen, percentBlue)) / value
+        switch createdState {
+        case .hue(_, let saturation, _, _):
+            return saturation
+        default:
+            return max(red, green, blue) == 0 ? 0 : (value - min(percentRed, percentGreen, percentBlue)) / value
+        }
     }
 
     /// Returns the value of this color represented as a percent in 0...1.
     public var value: CGFloat {
-        return max(percentRed, percentGreen, percentBlue)
+        switch createdState {
+        case .hue(_, _, let value, _):
+            return value
+        default:
+            return max(percentRed, percentGreen, percentBlue)
+        }
     }
-    
+
     /// Returns the intensity or saturation of the color.
     public var intensity: UInt8 {
         let redFactor = 0.299 * Double(red)
@@ -86,7 +101,7 @@ public struct ColorToken {
         let blueFactor = 0.114 * Double(blue)
         return UInt8(redFactor + greenFactor + blueFactor)
     }
-    
+
     /// Returns whether light colors will appear natural alongside this color.
     ///
     /// This is most useful for determining whether to select a light or dark text color for text
@@ -94,25 +109,33 @@ public struct ColorToken {
     public var complementsLightColors: Bool {
         return intensity < 186
     }
-    
+
     /// Returns the `UIColor` which corresponds with this color.
     public var uiColor: UIColor {
-        return UIColor(red: percentRed, green: percentGreen, blue: percentBlue, alpha: percentAlpha)
+        switch createdState{
+        case .uiColor(let color):
+            return color
+        default:
+            return UIColor(red: percentRed, green: percentGreen, blue: percentBlue, alpha: percentAlpha)
+        }
     }
-    
+
     /// Returns the `CGColor` which corresponds with this color.
     public var cgColor: CGColor {
         return uiColor.cgColor
     }
-    
+
+    private let createdState: CreatedState
+
     /// Creates a color with the given component values.
     public init(_ red: UInt8, _ green: UInt8, _ blue: UInt8, _ alpha: UInt8 = .max) {
         self.red = red
         self.green = green
         self.blue = blue
         self.alpha = alpha
+        createdState = .rgba(red: red, green: green, blue: blue, alpha: alpha)
     }
-    
+
     /// Creates a color by calculating the components for the given percents.
     public init(percents red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat = 1) {
         let toUInt8: (CGFloat) -> UInt8 = { UInt8(round(CGFloat(UInt8.max) * $0)) }
@@ -120,8 +143,9 @@ public struct ColorToken {
         self.green = toUInt8(green)
         self.blue = toUInt8(blue)
         self.alpha = toUInt8(alpha)
+        createdState = .percents(red: red, green: green, blue: blue, alpha: alpha)
     }
-    
+
     /// Creates a color from the components of the given `UIColor`.
     public init(from uiColor: UIColor) {
         var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
@@ -133,6 +157,7 @@ public struct ColorToken {
         self.green = toUInt8(green)
         self.blue = toUInt8(blue)
         self.alpha = toUInt8(alpha)
+        createdState = .uiColor(uiColor)
     }
 
     /// Creates a color from the given hue, saturation, and value on the unit scale (0...1).
@@ -171,39 +196,39 @@ public struct ColorToken {
         }
         self.init(percents: percentRed + m, percentGreen + m, percentBlue + m, alpha)
     }
-    
+
     /// Returns a color whose components are tinted by the supplied value.
     public func tinted(by value: UInt8) -> ColorToken {
         let clampToUInt8: (UInt8, UInt8) -> UInt8 = { UInt8(min(Int(UInt8.max), Int($0) + Int($1))) }
         return ColorToken(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
     }
-    
+
     /// Returns a color whose components are shaded by the supplied value.
     public func shaded(by value: UInt8) -> ColorToken {
         let clampToUInt8: (UInt8, UInt8) -> UInt8 = { UInt8(max(0, Int($0) - Int($1))) }
         return ColorToken(clampToUInt8(red, value), clampToUInt8(green, value), clampToUInt8(blue, value))
     }
-    
+
     /// Creates and returns a new color by substituting the red component of this color.
     public func withRed(_ red: UInt8) -> ColorToken {
         return ColorToken(red, green, blue, alpha)
     }
-    
+
     /// Creates and returns a new color by substituting the green component of this color.
     public func withGreen(_ green: UInt8) -> ColorToken {
         return ColorToken(red, green, blue, alpha)
     }
-    
+
     /// Creates and returns a new color by substituting the blue component of this color.
     public func withBlue(_ blue: UInt8) -> ColorToken {
         return ColorToken(red, green, blue, alpha)
     }
-    
+
     /// Creates and returns a new color by substituting the alpha component of this color.
     public func withAlpha(_ alpha: UInt8) -> ColorToken {
         return ColorToken(red, green, blue, alpha)
     }
-    
+
     /// Returns the hex string literal which represents this color.
     ///
     /// - Parameters:
@@ -221,37 +246,37 @@ public struct ColorToken {
 }
 
 public extension ColorToken {
-    
+
     /// The red hue.
     static let red = ColorToken(255, 0, 0)
-    
+
     /// The orange hue.
     static let orange = ColorToken(255, 127, 0)
-    
+
     /// The yellow hue.
     static let yellow = ColorToken(255, 255, 0)
-    
+
     /// The green hue.
     static let green = ColorToken(0, 255, 0)
 
     /// The cyan hue.
     static let cyan = ColorToken(0, 255, 255)
-    
+
     /// The blue hue.
     static let blue = ColorToken(0, 0, 255)
-    
+
     /// The purple hue.
     static let purple = ColorToken(127, 0, 127)
 
     /// The magenta hue.
     static let magenta = ColorToken(255, 0, 255)
-    
+
     /// The white color.
     static let white = ColorToken(255, 255, 255)
-    
+
     /// The black color.
     static let black = ColorToken(0, 0, 0)
-    
+
     /// A clear black color.
     static let clear = ColorToken(0, 0, 0, 0)
 
@@ -259,37 +284,46 @@ public extension ColorToken {
     static func transparent(_ color: ColorToken) -> ColorToken {
         return color.withAlpha(0)
     }
-    
+
     /// The system-appearance red color.
     static let systemRed = ColorToken(255, 59, 48)
-    
+
     /// The system-appearance orange color.
     static let systemOrange = ColorToken(255, 149, 0)
-    
+
     /// The system-appearance yellow color.
     static let systemYellow = ColorToken(255, 204, 0)
-    
+
     /// The system-appearance green color.
     static let systemGreen = ColorToken(76, 217, 100)
-    
+
     /// The system-appearance teal blue color.
     static let systemTealBlue = ColorToken(90, 200, 250)
-    
+
     /// The system-appearance blue color.
     static let systemBlue = ColorToken(0, 122, 255)
-    
+
     /// The system-appearance purple color.
     static let systemPurple = ColorToken(88, 86, 214)
-    
+
     /// The system-appearance pink color.
     static let systemPink = ColorToken(255, 45, 85)
-    
+
 }
 
-fileprivate extension UInt8 {
-    
+private extension UInt8 {
+
     var percent: CGFloat {
         return CGFloat(self) / CGFloat(UInt8.max)
     }
-    
+
+}
+
+private enum CreatedState {
+
+    case rgba(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8)
+    case percents(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+    case uiColor(UIColor)
+    case hue(CGFloat, saturation: CGFloat, value: CGFloat, alpha: CGFloat)
+
 }

--- a/Gooey/Sources/NSLayoutConstraint.swift
+++ b/Gooey/Sources/NSLayoutConstraint.swift
@@ -1,0 +1,19 @@
+//
+//  NSLayoutConstraint.swift
+//  Gooey
+//
+//  Created by James Power on 5/20/20.
+//  Copyright © 2020 Duet Health. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public extension GooeyNamespace where Base: NSLayoutConstraint {
+
+    func with(priority: UILayoutPriority) -> NSLayoutConstraint {
+        base.priority = priority
+        return base
+    }
+
+}

--- a/Gooey/Sources/NSLayoutConstraint.swift
+++ b/Gooey/Sources/NSLayoutConstraint.swift
@@ -11,7 +11,7 @@ import UIKit
 
 public extension GooeyNamespace where Base: NSLayoutConstraint {
 
-    func with(priority: UILayoutPriority) -> NSLayoutConstraint {
+    @discardableResult func with(priority: UILayoutPriority) -> NSLayoutConstraint {
         base.priority = priority
         return base
     }

--- a/GooeyTests/ConstraintGroupTests.swift
+++ b/GooeyTests/ConstraintGroupTests.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import Gooey
 import Nimble
 import Quick
+import UIKit
 
 extension Bool: Comparable {
 

--- a/GooeyTests/Info.plist
+++ b/GooeyTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
Adds function to set priority to ConstraintGroups, per https://github.com/DuetHealth/Gooey/issues/61

Adds function to create EdgeInsets<Bounds> by axis, e.g.:
`.byAxis(vertical: .system, horizontal: .system(2))`

Maybe should target develop here but not sure if we have any other things on the horizon we'd like to work on before making a new release?